### PR TITLE
Fix settings page and change references to incorrect plugin name,

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -113,9 +113,6 @@ function gamoteca_update_instance($moduleinstance, $mform = null) {
 function gamoteca_delete_instance($id) {
     global $DB;
 
-    // $DB->delete_records('config_plugins', array('plugin' => 'local_gamoteca'));
-    // unset_all_config_for_plugin('local_gamoteca');
-
     $exists = $DB->get_record('gamoteca', array('id' => $id));
     if (!$exists) {
         return false;
@@ -233,7 +230,7 @@ function gamoteca_cm_info_view(cm_info $coursemodule) {
     $additionalparams = $SITE->shortname . '|' . $coursemodule->course . '|' . $coursemodule->id . '|' . $USER->id;
 
     // Encrypt additional partner params
-    $encryptionPassphrase = get_config('local_gamoteca', 'encryption_key');
+    $encryptionPassphrase = get_config('mod_gamoteca', 'encryption_key');
     $additionalparamsEncrypted = mod_gamoteca_encrypt($additionalparams, sodium_hex2bin($encryptionPassphrase));
 
     if (parse_url($url, PHP_URL_QUERY)) {
@@ -390,7 +387,7 @@ function gamoteca_set_completion($gamoteca, $userid, $completionstate = COMPLETI
 function gamoteca_uninstall() {
     global $DB;
 
-    $DB->delete_records('config_plugins', array('plugin' => 'local_gamoteca'));
+    $DB->delete_records('config_plugins', array('plugin' => 'mod_gamoteca'));
 
     return true;
 }

--- a/settings.php
+++ b/settings.php
@@ -27,44 +27,23 @@ defined('MOODLE_INTERNAL') || die();
 // Ensure the configurations for this site are set
 if ( $hassiteconfig ){
 
-	// Create the new settings page
-	// - in a local plugin this is not defined as standard, so normal $settings->methods will throw an error as
-	// $settings will be NULL
-	$settings = new admin_settingpage( 'gamoteca', 'Gamoteca' );
-
-	// Create 
-	$ADMIN->add( 'localplugins', $settings );
-
-	// Add a setting field to the settings for this page
-    // $settings->add( new admin_setting_configpasswordunmask(
-		
-	// 	// This is the reference you will use to your configuration
-	// 	'local_gamoteca/encryptionkey',
-	
-	// 	// This is the friendly title for the config, which will be displayed
-	// 	'External Encryption Key',
-	
-	// 	// This is helper text for this config field
-	// 	'This is the key used to encrypt login credentials',
-	
-	// ) );
 	$settings->add( new admin_setting_configtext(
-		
+
 		// This is the reference you will use to your configuration
-		'local_gamoteca/encryption_key',
-	
+		'mod_gamoteca/encryption_key',
+
 		// This is the friendly title for the config, which will be displayed
 		'Encryption key',
-	
+
 		// This is helper text for this config field
 		'This key will be used to encrypt user & course details passed between the LMS and Gamoteca.',
-	
+
 		// This is the default value
 		'',
-	
+
 		// This is the type of Parameter this config is
 		PARAM_TEXT
-	
+
 	) );
 
 }


### PR DESCRIPTION
- Fixes settings page which was broken with a 'section' error.
- Changes settings to use correct plugin slug (mod_gamoteca) not (local_gamoteca)
- Removes/changes other references of local_gamoteca to mod_gamoteca.

Note: If users already have this plugin installed, they will need to set their encryption key again, as it will now look for the correct setting. If you wish, you could write an upgrade step to migrate any settings saved under 'local_gamoteca' to 'mod_gamoteca'.