### PR TITLE
Update mobile code 

### DIFF
--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -64,6 +64,7 @@ class mobile {
             'link' => $gamotecaurl,
             'cmid' => $cm->id,
             'logogamoteca' => $CFG->wwwroot . '/mod/gamoteca/pix/mobileicon.png',
+            'canusemoduleinfo' => $args->appversioncode >= 44000,
         ];
 
         return [

--- a/templates/mobile_view_page.mustache
+++ b/templates/mobile_view_page.mustache
@@ -21,8 +21,13 @@
 }}
 {{=<% %>=}}
 <div>
-    <core-course-module-description description="<% gamoteca.intro %>" component="mod_gamoteca" componentId="<% cmid %>"></core-course-module-description>
-
+    <%#canusemoduleinfo%>
+        <core-course-module-info [module]="module" description="<% gamoteca.intro %>" component="mod_gamoteca" componentId="<% cmid %>" [courseId]="courseId">
+        </core-course-module-info>
+    <%/canusemoduleinfo%>
+    <%^canusemoduleinfo%>
+        <core-course-module-description description="<% gamoteca.intro %>" component="mod_gamoteca" componentId="<% cmid %>"></core-course-module-description>
+    <%/canusemoduleinfo%>
 
     <ion-item  text-center>
         <img src="<% logogamoteca %>" core-external-content component="mod_gamoteca" style="width:250px">

--- a/templates/mobile_view_page.mustache
+++ b/templates/mobile_view_page.mustache
@@ -29,21 +29,29 @@
         <core-course-module-description description="<% gamoteca.intro %>" component="mod_gamoteca" componentId="<% cmid %>"></core-course-module-description>
     <%/canusemoduleinfo%>
 
-    <ion-item  text-center>
-        <img src="<% logogamoteca %>" core-external-content component="mod_gamoteca" style="width:250px">
+    <ion-item class="ion-text-center">
+        <ion-label>
+            <img src="<% logogamoteca %>" core-external-content component="mod_gamoteca" style="width:250px">
+        </ion-label>
     </ion-item>
-    <ion-item text-wrap text-center>
-   	    <p>
-    		{{ 'plugin.mod_gamoteca.gameotecatextmobile' | translate }}
-    	</p>
+    <ion-item class="ion-text-wrap ion-text-center">
+        <ion-label>
+            <p>
+                {{ 'plugin.mod_gamoteca.gameotecatextmobile' | translate }}
+            </p>
+        </ion-label>
     </ion-item>
-    <ion-item text-center>
-        <a href="<% link %>" target="_blank" core-link class="gamoteca-open-link">{{ 'plugin.mod_gamoteca.gameotecatextmobileopen' | translate }}</a>
+    <ion-item class="ion-text-center">
+        <ion-label>
+            <a href="<% link %>" target="_blank" core-link class="gamoteca-open-link">{{ 'plugin.mod_gamoteca.gameotecatextmobileopen' | translate }}</a>
+        </ion-label>
     </ion-item>
-    <ion-item text-wrap text-center>
-   	    <p>
-    		{{ 'plugin.mod_gamoteca.gameotecatextmobilepost' | translate }}
-    	</p>
+    <ion-item class="ion-text-wrap ion-text-center">
+        <ion-label>
+            <p>
+                {{ 'plugin.mod_gamoteca.gameotecatextmobilepost' | translate }}
+            </p>
+        </ion-label>
     </ion-item>
 
 </div>


### PR DESCRIPTION
In this PR I'm updating the HTML to use the proper syntax and classes used by Ionic 5+ (some of the syntax was still from Ionic 3). I also removed the usage of core-course-module-description component for new versions of the app, it is deprecated and will be removed in a future version of the app. It should have been removed already, but we kept it in the app because some plugins still use it.

**Important:** I wasn't able to test these changes because I got an error:

Exception - sodium_hex2bin(): Argument #1 ($string) must be a valid hexadecimal string.

The changes are similar to the ones done in other plugins so I think they should be safe, but it would be better if you could test it before integrating these changes.